### PR TITLE
Sort version using localCompare to avoid problems with strings

### DIFF
--- a/src/app/shared/modal/appinstall/appinstallmodal.component.ts
+++ b/src/app/shared/modal/appinstall/appinstallmodal.component.ts
@@ -42,7 +42,7 @@ export class AppInstallModalComponent implements OnInit {
     }
 
     ngOnInit() {
-        this.app.versions.sort((a, b) => a.version === b.version ? 0 : a.version < b.version ? -1 : 1);
+        this.app.versions.sort((a, b) => a.version.localeCompare(b.version, undefined, {numeric: true}));
         this.app.versions.reverse();
         this.selectedAppVersion = this.app.versions[0].appVersionId;
         this.domainId = this.domain.id;


### PR DESCRIPTION
Sort version using localCompare to avoid problems with string with dots sort problem. 